### PR TITLE
Fix Striker Jones model lookup

### DIFF
--- a/TacticalTweaksMod.cs
+++ b/TacticalTweaksMod.cs
@@ -117,9 +117,24 @@ public class TacticalTweaksMod : BloonsTD6Mod
             tacticalTweak.OnNewGameModel(gameModel);
         }
 
-        var strikerJones = gameModel.GetHeroWithNameAndLevel(TowerType.StrikerJones, 20);
-        strikerJones.AddBehavior(new SupportRemoveFilterOutTagModel("", "Striker:DdtDamageModifier",
-            "Striker:Level9BlackBuff", null, true, false, 0, "", ""));
+        var strikerJones = gameModel.GetTowersWithBaseId(TowerType.StrikerJones)
+            .AsIEnumerable()
+            .FirstOrDefault(model => model.tier == 20);
+
+        if (strikerJones is not null)
+        {
+            strikerJones.AddBehavior(new SupportRemoveFilterOutTagModel(
+                "",
+                "Striker:DdtDamageModifier",
+                "Striker:Level9BlackBuff",
+                null,
+                true,
+                false,
+                0,
+                "",
+                ""
+            ));
+        }
     }
 
     public override void OnTowerSaved(Tower tower, TowerSaveDataModel saveData)


### PR DESCRIPTION
## Summary
- Fixes Tactical Tweaks crashing during `OnNewGameModel` on newer BTD6 versions.
- Replaces the removed `GameModel.GetHeroWithNameAndLevel(...)` call with a `GetTowersWithBaseId(...)` lookup for level 20 Striker Jones.
- Adds a null guard before applying the Striker Jones behavior.

## Motivation
After a BTD6 update, Tactical Tweaks could fail to load/apply tweaks such as Dartling Gunner and Mortar targeting because the mod crashed with:

`System.MissingMethodException: Method not found: GameModel.GetHeroWithNameAndLevel(System.String, Int32)`

## Testing
- Built successfully with `dotnet build .\TacticalTweaks.sln -c Release --no-restore`